### PR TITLE
fix iterable serialization

### DIFF
--- a/src/gmaps/client.py
+++ b/src/gmaps/client.py
@@ -43,9 +43,11 @@ class Client(object):
         for key, value in parameters.items():
             if isinstance(value, bool):
                 parameters[key] = "true" if value else "false"
-            if isinstance(value, dict):
+            elif isinstance(value, dict):
                 parameters[key] = "|".join(
                     ("%s:%s" % (k, v) for k, v in value.items()))
+            elif isinstance(value, list) or isinstance(value, tuple):
+                parameters[key] = "|".join(val for val in value)
         return parameters
 
     def _make_request(self, url, parameters, result_key):

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -147,3 +147,9 @@ def test_directions_units():
     assert u"mi" in imperial["text"]
     # but value is the same (in meters)
     assert metric["value"] == imperial["value"]
+
+@retry
+def test_array_serialization():
+    tollsHighways = Directions().directions('paris', 'berlin', avoid=('tolls', 'highways'))[0]['legs'][0]['duration']
+    highwaysTolls = Directions().directions('paris', 'berlin', avoid=('highways', 'tolls'))[0]['legs'][0]['duration']
+    assert tollsHighways == highwaysTolls


### PR DESCRIPTION
Iterables are not serialized correctly, as demonstrated by the code below:

tollsHighways = Directions().directions('paris', 'berlin', avoid=('tolls', 'highways'))[0]['legs'][0]['duration']
highwaysTolls = Directions().directions('paris', 'berlin', avoid=('highways', 'tolls'))[0]['legs'][0]['duration']
assert tollsHighways == highwaysTolls

These changes fix that
